### PR TITLE
[#2] Jacoco 의존성 추가 및 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.1'
 	id 'io.spring.dependency-management' version '1.1.4'
+	id 'jacoco'
 }
 
 group = 'com.onezerokang'
@@ -9,6 +10,10 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
+}
+
+jacoco {
+	toolVersion = "0.8.9"
 }
 
 configurations {
@@ -35,4 +40,45 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	finalizedBy 'jacocoTestCoverageVerification'
+
+	reports {
+		xml.required = true
+		csv.required = true
+		html.required = true
+	}
+
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: [
+					'**/*Application*',
+			])
+		}))
+	}
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			element = 'CLASS'
+
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.8
+			}
+
+			excludes = [
+					'*.*Application',
+			]
+		}
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ jacocoTestCoverageVerification {
 			element = 'CLASS'
 
 			limit {
-				counter = 'LINE'
+				counter = 'BRANCH'
 				value = 'COVEREDRATIO'
 				minimum = 0.8
 			}


### PR DESCRIPTION
## 변경 사항 요약

- **jacoco 플러그인 추가**: 테스트 커버리지 측정을 위해 Jacoco 플러그인을 추가하였습니다.
- **테스트 태스크 실행**: `test` 태스크 실행 시 `jacocoTestReport` 태스크와 `jacocoTestCoverageVerification` 태스크가 순차적으로 실행되도록 설정하였습니다.
- **라인 커버리지 기준 설정**: 라인 커버리지가 80% 미만일 경우, 빌드가 실패하도록 설정하였습니다.
- **특정 파일에 대한 테스트 예외 처리**:
  - `**/*Application*` 파일은 테스트 리포트에서 제외되도록 처리하였습니다.
  - `*.*Application` 파일은 테스트 커버리지 검증에서 제외되도록 처리하였습니다.

## 고민했던 내용

- **테스트 커버리지 기준**: 테스트 커버리지 기준을 어떻게 설정할지에 대한 고민이 있었습니다(브랜치 커버리지 등). 현재는 프로젝트가 초기 단계에 있어 '라인 커버리지'를 80%로 설정했습니다. 추후 다른 측정 기준이 요구될 경우 조정하려고 합니다.